### PR TITLE
Change to read cert as string

### DIFF
--- a/src/RequestVerification/RequestVerification.js
+++ b/src/RequestVerification/RequestVerification.js
@@ -10,11 +10,29 @@ class RequestVerification {
     digitalSignatureService = new DigitalSignatureService();
   }
 
+  isFileSync(aPath) {
+    try {
+      return fs.statSync(aPath).isFile();
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  }
+
   verifyRequest(contents, cert, sig) {
 
-    const publicKey = fs.readFileSync(cert, 'utf8');
+    let publicKey = cert;
+
+    if(this.isFileSync(cert)){
+      publicKey = fs.readFileSync(cert, 'utf8');
+    }
+
     const verified = digitalSignatureService.verifyRequest(contents, publicKey, sig);
     return verified;
   }
+
 }
 module.exports = RequestVerification;

--- a/test/RequestVerificationTests/RequestVerification.test.js
+++ b/test/RequestVerificationTests/RequestVerification.test.js
@@ -21,6 +21,7 @@ describe('When verifying the request', () => {
   });
   it('the interactions certification is loaded', () => {
     sandbox.stub(DigitalSignatureService.prototype,'verifyRequest').returns(true);
+    sandbox.stub(fs,'statSync').returns({isFile: ()=>{return true;}});
     const mock = sinon.mock(fs);
     let expectedCert = './ssl/interactions.cert';
     mock.expects('readFileSync').once().withArgs(expectedCert, 'utf8').returns('abcdefg');
@@ -35,10 +36,24 @@ describe('When verifying the request', () => {
     let expectedCert = './ssl/interactions.cert';
     mock.expects('readFileSync').once().withArgs(expectedCert, 'utf8').returns(expectedCertContent);
     sandbox.stub(DigitalSignatureService.prototype,'verifyRequest').withArgs(`{"uuid":"${expectedUuid}","uid":"${expectedUid}"}`,expectedCertContent,expectedSig).returns(true);
+    sandbox.stub(fs,'statSync').returns({isFile: ()=>{return true;}});
 
     const actual = requestVerification.verifyRequest(`{"uuid":"${expectedUuid}","uid":"${expectedUid}"}`,expectedCert, expectedSig);
 
     expect(actual).to.equal(true);
     mock.verify();
   });
+  it('then if the cert in config is not a path but the value, it is used', () => {
+    let expectedCert = 'abajsbdakjsbd';
+     const mock = sinon.mock(fs);
+
+     mock.expects('readFileSync').never();
+
+
+    sandbox.stub(DigitalSignatureService.prototype,'verifyRequest').withArgs(`{"uuid":"${expectedUuid}","uid":"${expectedUid}"}`,expectedCert,expectedSig).returns(true);
+
+    requestVerification.verifyRequest(`{"uuid":"${expectedUuid}","uid":"${expectedUid}"}`,expectedCert, expectedSig);
+
+    mock.verify();
+  })
 });


### PR DESCRIPTION
Change so that if the certificate is not a path, the parameter value is read as the public key