### PR TITLE
[DSI-7339] Bump major version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.request-verification",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.request-verification",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.53.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.request-verification",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "request verification",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
### Changes
When release tagging DSI-7339, https://github.com/DFE-Digital/login.dfe.request-verification/pull/5, it identified breaking changes from yesteryear.  The changes are a refactor of the components public API, rather than the implementation detail of validating a payload, which remains compatible.  However, with the public API different, and of a breaking change, this necessitates a major version bump, which should prevent consumers automatically updating the package.  